### PR TITLE
Feat/structure

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,4 +1,5 @@
 import 'package:auralys/core/router/routes.dart';
+import 'package:auralys/features/intro/screens/loader_screen.dart';
 import 'package:auralys/features/intro/screens/splash_screen.dart';
 import 'package:auralys/shared/error_screen.dart';
 import 'package:go_router/go_router.dart';
@@ -11,6 +12,13 @@ class AppRouter {
         path: APP_PAGES.splash.toPath,
         name: APP_PAGES.splash.toName,
         builder: (context, state) => SplashScreen(),
+        routes: <GoRoute>[
+          GoRoute(
+            path: APP_PAGES.loader.toPath,
+            name: APP_PAGES.loader.toName,
+            builder: (context, state) => LoaderScreen(),
+          )
+        ]
       ),
       /* GoRoute(
         path: APP_PAGES.welcome.toPath,

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -1,13 +1,8 @@
-enum APP_PAGES {
-  splash,
-  login,
-  register,
-  home,
-  welcome,
-}
+enum APP_PAGES { splash, loader, login, register, home, welcome }
 
 abstract class Routes {
   static const String splash = "/";
+  static const String loader = "/loader";
   static const String login = "/login";
   static const String register = "/register";
   static const String home = "/home";
@@ -21,6 +16,8 @@ extension AppPageExtension on APP_PAGES {
     switch (this) {
       case APP_PAGES.splash:
         return Routes.splash;
+      case APP_PAGES.loader:
+        return Routes.loader;
       case APP_PAGES.login:
         return Routes.login;
       case APP_PAGES.register:

--- a/lib/features/intro/screens/splash_screen.dart
+++ b/lib/features/intro/screens/splash_screen.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/router/routes.dart';
 
 class SplashScreen extends StatelessWidget {
   const SplashScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    Future.delayed(const Duration(seconds: 3), () {
+      // Navigate to the loader screen after the splash screen
+      context.pushNamed(APP_PAGES.loader.toName);
+    });
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,10 +7,16 @@ import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(const MyApp());
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  runApp(MultiProvider(providers: [
+    ChangeNotifierProvider(
+        create: (_) => AppStateProvider(prefs)..loadPreferences()),
+  ], child: MyApp()));
   configLoading();
 }
 


### PR DESCRIPTION
This pull request introduces a new `LoaderScreen` to the app's navigation flow, updates the routing logic to include it, and initializes shared preferences for managing app state. The most important changes include adding the `LoaderScreen` route, modifying the splash screen to navigate to the loader screen, and setting up shared preferences in the app's main entry point.

### Routing Updates:
* Added `LoaderScreen` to the app's routing configuration in `lib/core/router/app_router.dart` and updated the `APP_PAGES` enum and routing paths in `lib/core/router/routes.dart`. (`[[1]](diffhunk://#diff-4fa1adae1da4e07e21097640e2ed27cccb98dac7e5a409a193d2503c660107e6R2)`, `[[2]](diffhunk://#diff-4fa1adae1da4e07e21097640e2ed27cccb98dac7e5a409a193d2503c660107e6R15-R21)`, `[[3]](diffhunk://#diff-4ebfb0a71397895d6e79eecb26e704ff81afa7c8d4cc3dd512ea58a371a009fbL1-R5)`, `[[4]](diffhunk://#diff-4ebfb0a71397895d6e79eecb26e704ff81afa7c8d4cc3dd512ea58a371a009fbR19-R20)`)

### Splash Screen Behavior:
* Modified `SplashScreen` in `lib/features/intro/screens/splash_screen.dart` to navigate to the `LoaderScreen` after a 3-second delay. (`[lib/features/intro/screens/splash_screen.dartR2-R14](diffhunk://#diff-0890efa5bea7e6f7b964ee017c798530ddc3f982c325f38d97a9cbf87c2d1c14R2-R14)`)

### App Initialization:
* Updated `main.dart` to initialize `SharedPreferences` and set up an `AppStateProvider` for managing app state. (`[lib/main.dartR10-R19](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R10-R19)`)